### PR TITLE
WIP: Highlight missing \

### DIFF
--- a/Dockerfile.sublime-syntax
+++ b/Dockerfile.sublime-syntax
@@ -44,6 +44,14 @@ contexts:
         1: punctuation.definition.string.begin.dockerfile
       push:
         - meta_scope: string.quoted.double.dockerfile
+        - match: ([^\\\s"])(\s*$)
+#          captures:
+#            2: invalid.deprecated
+          push:
+            - match: (^\s*[^\s"]+)
+              captures:
+                1: invalid
+              pop: true
         - match: '"'
           captures:
             1: punctuation.definition.string.end.dockerfile
@@ -55,6 +63,14 @@ contexts:
         1: punctuation.definition.string.begin.dockerfile
       push:
         - meta_scope: string.quoted.single.dockerfile
+        - match: ([^\\\s'])(\s*$)
+#          captures:
+#            2: invalid.deprecated
+          push:
+            - match: (^\s*[^\s']+)
+              captures:
+                1: invalid
+              pop: true
         - match: "'"
           captures:
             1: punctuation.definition.string.end.dockerfile

--- a/Dockerfile.sublime-syntax
+++ b/Dockerfile.sublime-syntax
@@ -13,7 +13,8 @@ contexts:
     - include: comments
 
   newline:
-    - match: ([^\\\s])\s*(\n)
+    - match: ([^\\\s])\s*$
+      # scope: invalid.dockerfile
       # captures:
       #   1: invalid.begin.dockerfile
       #   2: invalid.begin.dockerfile
@@ -21,7 +22,7 @@ contexts:
         - include: keywords
         - include: quotes
         - include: comments
-        - match: (^\s*\S)
+        - match: (^\s*\S+)
           captures:
             1: invalid.end.dockerfile
           pop: true

--- a/Dockerfile.sublime-syntax
+++ b/Dockerfile.sublime-syntax
@@ -7,14 +7,37 @@ file_extensions:
 scope: source.dockerfile
 contexts:
   main:
+    - include: keywords
+    - include: newline
+    - include: quotes
+    - include: comments
+
+  newline:
+    - match: ([^\\\s])\s*(\n)
+      # captures:
+      #   1: invalid.begin.dockerfile
+      #   2: invalid.begin.dockerfile
+      push:
+        - include: keywords
+        - include: quotes
+        - include: comments
+        - match: (^\s*\S)
+          captures:
+            1: invalid.end.dockerfile
+          pop: true
+  keywords:
     - match: ^\s*(?:(ONBUILD)\s+)?(ADD|ARG|COPY|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s
       captures:
         1: keyword.control.dockerfile
         2: keyword.other.special-method.dockerfile
+      pop: true
     - match: ^\s*(?:(ONBUILD)\s+)?(CMD|ENTRYPOINT)\s
       captures:
         1: keyword.operator.dockerfile
         2: keyword.other.special-method.dockerfile
+      pop: true
+
+  quotes:
     - match: '"'
       captures:
         1: punctuation.definition.string.begin.dockerfile
@@ -37,6 +60,7 @@ contexts:
           pop: true
         - match: \\.
           scope: constant.character.escaped.dockerfile
+  comments:
     - match: ^(\s*)((#).*$\n?)
       comment: comment.line
       captures:


### PR DESCRIPTION
I'm trying to add a special syntax highlight case. I want the newlines not starting with keywords to be highlighted. For example

```
RUN cd /tmp
    touch file
```

Results in the spaces and the word `touch` being highlighted in the invalid color. The purpose of this is to catch missing `\`'s when writing a docker file.

Currently the only bug with this is, the following example is not highlighted

```
RUN echo "Hello
    world"
    ls
```

Because the quote match ends before the newline match can end, and this can not match the newline pattern. I don't know the syntax language enough to fix this.

@asbjornenge Are you interested in this idea?