### PR TITLE
Fix escaped char in directive args

### DIFF
--- a/Dockerfile.sublime-syntax
+++ b/Dockerfile.sublime-syntax
@@ -35,10 +35,15 @@ contexts:
         1: keyword.other.special-method.dockerfile
       push: args
 
+  escaped-char:
+    - match: \\.
+      scope: constant.character.escaped.dockerfile
+
   args:
+    - include: comments
+    - include: escaped-char
     - match: ^\s*$
     - match: \\\s+$
-    - include: comments
     - match: \n
       pop: true
     - match: '"'
@@ -52,12 +57,11 @@ contexts:
 
   double_quote_string:
     - meta_scope: string.quoted.double.dockerfile
+    - include: escaped-char
     - match: ^\s*$
     - match: \\\s+$
     - match: \n
       set: invalid
-    - match: \\.
-      scope: constant.character.escaped.dockerfile
     - match: '"'
       captures:
         0: punctuation.definition.string.end.dockerfile
@@ -65,12 +69,11 @@ contexts:
 
   single_quote_string:
     - meta_scope: string.quoted.single.dockerfile
+    - include: escaped-char
     - match: ^\s*$
     - match: \\\s+$
     - match: \n
       set: invalid
-    - match: \\.
-      scope: constant.character.escaped.dockerfile
     - match: "'"
       captures:
         0: punctuation.definition.string.end.dockerfile


### PR DESCRIPTION
fix #8 

Escaped chars in directive args were not handled, this PR fixes it.

![screenshot 2016-09-20](https://cloud.githubusercontent.com/assets/1329716/18666977/fa64455a-7f71-11e6-99bf-3195ce540c3d.png)
