### PR TITLE
Update Dockerfile.tmLanguage

### DIFF
--- a/Syntaxes/Dockerfile.tmLanguage
+++ b/Syntaxes/Dockerfile.tmLanguage
@@ -11,6 +11,12 @@
 	<key>patterns</key>
 	<array>
 		<dict>
+			<key>match</key>
+			<string>\\.</string>
+			<key>name</key>
+			<string>constant.character.escaped.dockerfile</string>
+		</dict>
+		<dict>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Accept escaped chars on top level, fixes #8 on the tmLanguage side

Maybe someone will want to refactor it...