### PR TITLE
Added first line detection for #16

### DIFF
--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -4,6 +4,7 @@
 name: Dockerfile
 file_extensions:
   - Dockerfile
+first_line_match: \s*(FROM|ARG)\s
 scope: source.dockerfile
 
 variables:


### PR DESCRIPTION
It looks like submline-syntax only supports extension and first_line_match.

extension was already set to Dockerfile, which covers `(.*\.)?[dD]ockerfile`, but not `[d|D]ockerfile\..+`.

I added first line starts with either `^FROM` or `^ARG`. This won't work for people who put comments first, but that is the limit of what I know how about sublime-syntax ;)