### PR TITLE
Corrected first_line_match: only match "from" or "arg" in the beginning of the line

### DIFF
--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -5,7 +5,7 @@ name: Dockerfile
 file_extensions:
   - Dockerfile
   - dockerfile
-first_line_match: \s*(?i:(from|arg))\s
+first_line_match: ^\s*(?i:(from|arg))\s
 scope: source.dockerfile
 
 variables:


### PR DESCRIPTION
`first_line_match` does not have implicit `^$`. As a result, the rule was matching things like `import blah from 'blah'`, which occasionally marked non-docker files without explicit file extensions, or in unsaved buffers, as dockerfiles. This PR fixes it.