### PR TITLE
Embed shellscript in the appropriate places

### DIFF
--- a/Syntaxes/Dockerfile-bash.sublime-syntax
+++ b/Syntaxes/Dockerfile-bash.sublime-syntax
@@ -1,0 +1,84 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Dockerfile (with bash)
+
+scope: source.dockerfile.bash
+
+variables:
+  identifier: '[[:alnum:]]+'
+  onbuild_directive: (?i:(onbuild)\s+)?
+  onbuild_commands_directive:
+    "{{onbuild_directive}}(?i:add|arg|env|copy|expose|healthcheck|label|shell|stopsignal|user|volume|workdir)"
+  nononbuild_commands_directive: (?i:maintainer)
+  embeddable_directive: '{{onbuild_directive}}(?i:run|cmd|entrypoint)'
+  from_directive: (?i:(from))\s+[^\s:@]+(?:[:@](\S+))?(?:\s+(?i:(as))\s+(\S+))?
+
+contexts:
+  prototype:
+    - include: scope:source.shell.bash#prototype
+
+  main:
+    - match: ^(?i:arg)\s
+      scope: keyword.control.dockerfile
+    - include: from
+
+  expect-container-tag:
+    - match: ({{identifier}})(?:([:@])(\S+))?
+      captures:
+        1: entity.name.label.dockerfile
+        2: punctuation.separator.dockerfile
+        3: constant.numeric.dockerfile
+      pop: true
+
+  optional-as:
+    - match: (?i)\s*as\b
+      scope: keyword.control.dockerfile
+      set:
+        - match: \S+
+          scope: variable.stage-name.dockerfile
+          pop: true
+        - match: $
+          pop: true
+    - match: ""
+      pop: true
+
+  from:
+    - match: ^\s*(?i:(from))\b
+      captures:
+        1: keyword.control.dockerfile
+      set: [body, optional-as, expect-container-tag]
+
+  body:
+    - include: directives
+    - include: from
+    - include: invalid
+
+  directives:
+    - match: ^\s*({{embeddable_directive}})\b
+      captures:
+        1: keyword.control.dockerfile
+      push:
+        - match: (?=\s*\[)
+          set: scope:source.json#array
+          with_prototype:
+            - match: \n
+              pop: true
+        - match: ""
+          set: scope:source.shell.bash
+          with_prototype:
+            - include: scope:source.shell.bash#prototype
+            - match: \n|^(?=\S)
+              pop: true
+    - match: ^\s*{{onbuild_commands_directive}}\s
+      captures:
+        0: keyword.control.dockerfile
+        1: keyword.other.special-method.dockerfile
+      push: scope:source.shell.bash#cmd-args
+    - match: ^\s*{{nononbuild_commands_directive}}\s
+      scope: keyword.control.dockerfile
+      push: scope:source.shell.bash#cmd-args
+
+  invalid:
+    - match: ^[^A-Z\n](.*)$
+      scope: invalid.illegal.dockerfile

--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -9,79 +9,106 @@ first_line_match: ^\s*(?i:(from|arg))\s
 scope: source.dockerfile
 
 variables:
-  identifier: '[[:alnum:]]+'
   onbuild_directive: (?i:(onbuild)\s+)?
   onbuild_commands_directive:
-    "{{onbuild_directive}}(?i:add|arg|env|copy|expose|healthcheck|label|shell|stopsignal|user|volume|workdir)"
+    "{{onbuild_directive}}(?i:add|arg|env|expose|healthcheck|label|run|shell|stopsignal|user|volume|workdir)"
   nononbuild_commands_directive: (?i:maintainer)
-  embeddable_directive: '{{onbuild_directive}}(?i:run|cmd|entrypoint)'
+  runtime_directive: "{{onbuild_directive}}(?i:cmd|entrypoint)"
   from_directive: (?i:(from))\s+[^\s:@]+(?:[:@](\S+))?(?:\s+(?i:(as))\s+(\S+))?
+  copy_directive: ({{onbuild_directive}}(?i:copy))(?:\s+--from=(\S+))?
 
 contexts:
-  prototype:
-    - include: scope:source.shell.bash#prototype
-
   main:
+    - include: comments
     - match: ^(?i:arg)\s
       scope: keyword.control.dockerfile
     - include: from
 
-  expect-container-tag:
-    - match: ({{identifier}})(?:([:@])(\S+))?
-      captures:
-        1: entity.name.label.dockerfile
-        2: punctuation.separator.dockerfile
-        3: constant.numeric.dockerfile
-      pop: true
-
-  optional-as:
-    - match: (?i)\s*as\b
-      scope: keyword.control.dockerfile
-      set:
-        - match: \S+
-          scope: variable.stage-name.dockerfile
-          pop: true
-        - match: $
-          pop: true
-    - match: ""
-      pop: true
-
   from:
-    - match: ^\s*(?i:(from))\b
+    - match: ^{{from_directive}}
       captures:
         1: keyword.control.dockerfile
-      set: [body, optional-as, expect-container-tag]
+        2: entity.name.enum.tag-digest
+        3: keyword.control.dockerfile
+        4: variable.stage-name
+      push: body
 
   body:
+    - include: comments
     - include: directives
-    - include: from
     - include: invalid
+    - include: from
 
   directives:
-    - match: ^\s*({{embeddable_directive}})\b
-      captures:
-        1: keyword.control.dockerfile
-      push:
-        - match: (?=\s*\[)
-          set: scope:source.json#array
-          with_prototype:
-            - match: \n
-              pop: true
-        - match: ""
-          set: scope:source.shell.bash
-          with_prototype:
-            - include: scope:source.shell.bash#prototype
-            - match: \n|^(?=\S)
-              pop: true
     - match: ^\s*{{onbuild_commands_directive}}\s
       captures:
         0: keyword.control.dockerfile
         1: keyword.other.special-method.dockerfile
-      push: scope:source.shell.bash#cmd-args
+      push: args
     - match: ^\s*{{nononbuild_commands_directive}}\s
       scope: keyword.control.dockerfile
-      push: scope:source.shell.bash#cmd-args
+      push: args
+    - match: ^\s*{{copy_directive}}\s
+      captures:
+        1: keyword.control.dockerfile
+        2: keyword.other.special-method.dockerfile
+        3: variable.stage-name
+      push: args
+    - match: ^\s*{{runtime_directive}}\s
+      captures:
+        0: keyword.operator.dockerfile
+        1: keyword.other.special-method.dockerfile
+      push: args
+
+  escaped-char:
+    - match: \\.
+      scope: constant.character.escaped.dockerfile
+
+  args:
+    - include: comments
+    - include: escaped-char
+    - match: ^\s*$
+    - match: \\\s+$
+    - match: \n
+      pop: true
+    - match: '"'
+      scope: punctuation.definition.string.begin.dockerfile
+      push: double_quote_string
+    - match: "'"
+      scope: punctuation.definition.string.begin.dockerfile
+      push: single_quote_string
+
+  double_quote_string:
+    - meta_scope: string.quoted.double.dockerfile
+    - include: escaped-char
+    - match: ^\s*$
+    - match: \\\s+$
+    - match: \n
+      set: invalid
+    - match: '"'
+      scope: punctuation.definition.string.end.dockerfile
+      pop: true
+
+  single_quote_string:
+    - meta_scope: string.quoted.single.dockerfile
+    - include: escaped-char
+    - match: ^\s*$
+    - match: \\\s+$
+    - match: \n
+      set: invalid
+    - match: "'"
+      scope: punctuation.definition.string.end.dockerfile
+      pop: true
+
+  comments:
+    - match: ^(\s*)((#).*$\n?)
+      comment: comment.line
+      captures:
+        1: punctuation.whitespace.comment.leading.dockerfile
+        2: comment.dockerfile
+        3: punctuation.definition.comment.dockerfile
 
   invalid:
     - match: ^[^A-Z\n](.*)$
-      scope: invalid.illegal.dockerfile
+      scope: invalid
+      set: body

--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -71,7 +71,7 @@ contexts:
           set: scope:source.shell.bash
           with_prototype:
             - include: scope:source.shell.bash#prototype
-            - match: \n
+            - match: \n|^(?=\S)
               pop: true
     - match: ^\s*{{onbuild_commands_directive}}\s
       captures:

--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -9,106 +9,79 @@ first_line_match: ^\s*(?i:(from|arg))\s
 scope: source.dockerfile
 
 variables:
+  identifier: '[[:alnum:]]+'
   onbuild_directive: (?i:(onbuild)\s+)?
   onbuild_commands_directive:
-    "{{onbuild_directive}}(?i:add|arg|env|expose|healthcheck|label|run|shell|stopsignal|user|volume|workdir)"
+    "{{onbuild_directive}}(?i:add|arg|env|copy|expose|healthcheck|label|shell|stopsignal|user|volume|workdir)"
   nononbuild_commands_directive: (?i:maintainer)
-  runtime_directive: "{{onbuild_directive}}(?i:cmd|entrypoint)"
+  embeddable_directive: '{{onbuild_directive}}(?i:run|cmd|entrypoint)'
   from_directive: (?i:(from))\s+[^\s:@]+(?:[:@](\S+))?(?:\s+(?i:(as))\s+(\S+))?
-  copy_directive: ({{onbuild_directive}}(?i:copy))(?:\s+--from=(\S+))?
 
 contexts:
+  prototype:
+    - include: scope:source.shell.bash#prototype
+
   main:
-    - include: comments
     - match: ^(?i:arg)\s
       scope: keyword.control.dockerfile
     - include: from
 
+  expect-container-tag:
+    - match: ({{identifier}})(?:([:@])(\S+))?
+      captures:
+        1: entity.name.label.dockerfile
+        2: punctuation.separator.dockerfile
+        3: constant.numeric.dockerfile
+      pop: true
+
+  optional-as:
+    - match: (?i)\s*as\b
+      scope: keyword.control.dockerfile
+      set:
+        - match: \S+
+          scope: variable.stage-name.dockerfile
+          pop: true
+        - match: $
+          pop: true
+    - match: ""
+      pop: true
+
   from:
-    - match: ^{{from_directive}}
+    - match: ^\s*(?i:(from))\b
       captures:
         1: keyword.control.dockerfile
-        2: entity.name.enum.tag-digest
-        3: keyword.control.dockerfile
-        4: variable.stage-name
-      push: body
+      set: [body, optional-as, expect-container-tag]
 
   body:
-    - include: comments
     - include: directives
-    - include: invalid
     - include: from
+    - include: invalid
 
   directives:
+    - match: ^\s*({{embeddable_directive}})\b
+      captures:
+        1: keyword.control.dockerfile
+      push:
+        - match: (?=\s*\[)
+          set: scope:source.json#array
+          with_prototype:
+            - match: \n
+              pop: true
+        - match: ""
+          set: scope:source.shell.bash
+          with_prototype:
+            - include: scope:source.shell.bash#prototype
+            - match: \n
+              pop: true
     - match: ^\s*{{onbuild_commands_directive}}\s
       captures:
         0: keyword.control.dockerfile
         1: keyword.other.special-method.dockerfile
-      push: args
+      push: scope:source.shell.bash#cmd-args
     - match: ^\s*{{nononbuild_commands_directive}}\s
       scope: keyword.control.dockerfile
-      push: args
-    - match: ^\s*{{copy_directive}}\s
-      captures:
-        1: keyword.control.dockerfile
-        2: keyword.other.special-method.dockerfile
-        3: variable.stage-name
-      push: args
-    - match: ^\s*{{runtime_directive}}\s
-      captures:
-        0: keyword.operator.dockerfile
-        1: keyword.other.special-method.dockerfile
-      push: args
-
-  escaped-char:
-    - match: \\.
-      scope: constant.character.escaped.dockerfile
-
-  args:
-    - include: comments
-    - include: escaped-char
-    - match: ^\s*$
-    - match: \\\s+$
-    - match: \n
-      pop: true
-    - match: '"'
-      scope: punctuation.definition.string.begin.dockerfile
-      push: double_quote_string
-    - match: "'"
-      scope: punctuation.definition.string.begin.dockerfile
-      push: single_quote_string
-
-  double_quote_string:
-    - meta_scope: string.quoted.double.dockerfile
-    - include: escaped-char
-    - match: ^\s*$
-    - match: \\\s+$
-    - match: \n
-      set: invalid
-    - match: '"'
-      scope: punctuation.definition.string.end.dockerfile
-      pop: true
-
-  single_quote_string:
-    - meta_scope: string.quoted.single.dockerfile
-    - include: escaped-char
-    - match: ^\s*$
-    - match: \\\s+$
-    - match: \n
-      set: invalid
-    - match: "'"
-      scope: punctuation.definition.string.end.dockerfile
-      pop: true
-
-  comments:
-    - match: ^(\s*)((#).*$\n?)
-      comment: comment.line
-      captures:
-        1: punctuation.whitespace.comment.leading.dockerfile
-        2: comment.dockerfile
-        3: punctuation.definition.comment.dockerfile
+      push: scope:source.shell.bash#cmd-args
 
   invalid:
     - match: ^[^A-Z\n](.*)$
-      scope: invalid
-      set: body
+      scope: invalid.illegal.dockerfile


### PR DESCRIPTION
I've been using this modified branch for a while now, and it works great for my purposes. Basically we include the shell script syntax where appropriate to get highlighting for `RUN` commands et al. Also, a part of the JSON syntax is included for things like `ENTRYPOINT`.

Here is a screenshot on how that looks:

<img width="1643" alt="schermafbeelding 2018-05-21 om 10 07 39" src="https://user-images.githubusercontent.com/2431823/40297155-196dd406-5cdf-11e8-872d-45c647b2897c.png">