### PR TITLE
Prevent confusion with Python files

### DIFF
--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -5,7 +5,7 @@ name: Dockerfile
 file_extensions:
   - Dockerfile
   - dockerfile
-first_line_match: ^\s*(?i:(from|arg))\s
+first_line_match: ^\s*(?i:(from(?!\s+\S+\s+import)|arg))\s+
 scope: source.dockerfile
 
 variables:


### PR DESCRIPTION
The previous first line match regex was too liberal - it matched with Python files that began with `from ... import ...`. This modifies the first line match regex to include a negative lookahead assertion that prevents matching if `import` is found. This does not create any more false negatives, because the `import` keyword is only expected after exactly one non-whitespace token, which is impossible in a syntactically correct Dockerfile.