### PR TITLE
Assign syntax to .Dockerfile

### DIFF
--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -2,11 +2,16 @@
 ---
 # http://www.sublimetext.com/docs/3/syntax.html
 name: Dockerfile
+scope: source.dockerfile
+
 file_extensions:
   - Dockerfile
   - dockerfile
+
+hidden_file_extensions:
+  - .Dockerfile
+
 first_line_match: ^\s*(?i:(from(?!\s+\S+\s+import)|arg))\s+
-scope: source.dockerfile
 
 variables:
   onbuild_directive: (?i:(onbuild)\s+)?


### PR DESCRIPTION
This commit adds a hidden file extension to assign syntax to `.Dockerfile` files.

_Note: That's required for A File Icon to be able to assign dedicated icon to such files._