### PR TITLE
Allow FROM directive to be highlighted differently

### DIFF
--- a/Syntaxes/Dockerfile-bash.sublime-syntax
+++ b/Syntaxes/Dockerfile-bash.sublime-syntax
@@ -32,7 +32,7 @@ contexts:
   from:
     - match: ^{{from_directive}}
       captures:
-        1: keyword.control.dockerfile
+        1: keyword.control.dockerfile.from
         2: entity.name.enum.tag-digest
         3: keyword.control.dockerfile
         4: variable.stage-name

--- a/Syntaxes/Dockerfile-bash.sublime-syntax
+++ b/Syntaxes/Dockerfile-bash.sublime-syntax
@@ -50,7 +50,7 @@ contexts:
         1: keyword.control.dockerfile
       push:
         - match: (?=\s*\[)
-          set: scope:source.json#array
+          set: scope:source.json#arrays
           with_prototype:
             - match: \n
               pop: true

--- a/Syntaxes/Dockerfile-bash.sublime-syntax
+++ b/Syntaxes/Dockerfile-bash.sublime-syntax
@@ -32,7 +32,7 @@ contexts:
   from:
     - match: ^{{from_directive}}
       captures:
-        1: keyword.control.dockerfile.from
+        1: keyword.control.from.dockerfile
         2: entity.name.enum.tag-digest
         3: keyword.control.dockerfile
         4: variable.stage-name

--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -32,7 +32,7 @@ contexts:
   from:
     - match: ^{{from_directive}}
       captures:
-        1: keyword.control.dockerfile
+        1: keyword.control.dockerfile.from
         2: entity.name.enum.tag-digest
         3: keyword.control.dockerfile
         4: variable.stage-name

--- a/Syntaxes/Dockerfile.sublime-syntax
+++ b/Syntaxes/Dockerfile.sublime-syntax
@@ -32,7 +32,7 @@ contexts:
   from:
     - match: ^{{from_directive}}
       captures:
-        1: keyword.control.dockerfile.from
+        1: keyword.control.from.dockerfile
         2: entity.name.enum.tag-digest
         3: keyword.control.dockerfile
         4: variable.stage-name


### PR DESCRIPTION
If `FROM` directive looks like the directives, it's difficult to catch stages in multi-stage Dockerfiles. This leaves the default case exactly as it was before but adds an option to color `FROM` differently for people who want it.